### PR TITLE
fix AsyncStorage save router and back error

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -18,6 +18,7 @@ app.router(() => <Router />)
 const App = app.start()
 
 // eslint-disable-next-line no-underscore-dangle
-persistStore(app._store, { storage: AsyncStorage })
+// fix AsyncStorage save router and back error
+persistStore(app._store, { blacklist: ['router'], storage: AsyncStorage })
 
 AppRegistry.registerComponent('DvaStarter', () => App)


### PR DESCRIPTION
由于redux-persist 缓存路由信息，修改路由并刷新后导致错误