### PR TITLE
Fix blank screen(#37)

### DIFF
--- a/app/models/router.js
+++ b/app/models/router.js
@@ -5,9 +5,14 @@ const actions = [
   NavigationActions.BACK,
   NavigationActions.INIT,
   NavigationActions.NAVIGATE,
+  NavigationActions.POP,
+  NavigationActions.POP_TO_TOP,
+  NavigationActions.PUSH,
   NavigationActions.RESET,
+  NavigationActions.REPLACE,
   NavigationActions.SET_PARAMS,
   NavigationActions.URI,
+  NavigationActions.COMPLETE_TRANSITION,
 ]
 
 export default {
@@ -29,10 +34,12 @@ export default {
             type: 'apply',
             payload,
           })
+          /* 这种解决debounce的方式会导致其他正常的nav action无法生效
           // debounce, see https://github.com/react-community/react-navigation/issues/271
           if (payload.type === 'Navigation/NAVIGATE') {
             yield call(delay, 500)
           }
+          */
         }
       },
       { type: 'watcher' },


### PR DESCRIPTION
注释掉了`debounce`部分代码：
```js
if (payload.type === 'Navigation/NAVIGATE') {
    yield call(delay, 500);
}
```
原因是段代码会导致每当路由跳转时，`500ms`内所有的`navigation action`都不会被执行，这不是理想的解决快速双击跳转两次的方案。